### PR TITLE
API:Langlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [rollback.py](python/rollback.py): rollback the last edits made to a given page
 * [API:Allfileusages](https://www.mediawiki.org/wiki/API:Allfileusages)
   * [get_allfileusages.py](python/get_allfileusages.py): list of all file usages
+* [API:Langlinks](https://www.mediawiki.org/wiki/API:Langlinks)
+  * [get_langlinks.py](python/get_langlinks.py): Gets a list of first 20 language links with the localised language name.
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/modules.json
+++ b/modules.json
@@ -427,6 +427,19 @@
             "list": "exturlusage",
             "euquery": "slashdot.org"
     	}
+    },
+    {
+        "filename": "get_langlinks.py",
+        "docstring": "Demo of `Langlinks` module: Demo to gets a list of first 20 language links from the provided pages to other languages.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+                "action" : "query",
+    		"format" : "json",
+    		"titles" : "Main Page",
+    		"prop"   : "langlinks",
+    		"lllimit": "20",
+    		"llprop" : "langname"
+    	}
     }
 ]
     

--- a/python/get_langlinks.py
+++ b/python/get_langlinks.py
@@ -1,0 +1,34 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    get_langlinks.py
+
+    MediaWiki Action API Code Samples
+    Demo of `Langlinks` module: Demo to gets a list of first 20 language links from the provided pages to other languages.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+#list of first 20 language links with the localised language name.
+
+PARAMS = {
+    "llprop" : "langname",
+    "format" : "json",
+    "lllimit": "20",
+    "prop"   : "langlinks",
+    "titles" : "Main Page",
+    "action" : "query"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Demo of `Langlinks` module : GET request to list of first 20 language links with the localised language name.
Following are the files changed:
README.md
modules.json
python/get_langlinks.py

Documentation: https://www.mediawiki.org/wiki/User:Supriya_Supugade/Sandbox/API:Langlinks

@srish Looking forward for your reviews.!! Thanks.!! :)