### PR TITLE
Add Python sample code for API:Protectedtitles

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -450,5 +450,17 @@
             "list": "pagepropnames",
             "format": "json"
         }
+    },
+    {
+        "filename": "get_protectedtitles",
+        "docstring": "Demo of `Protectedtitles` module: Get the first 2 titles which only sysops can create",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "protectedtitles",
+            "ptlevel": "sysop",
+            "ptlimit": "2"
+        }
     }
 ]

--- a/python/README.md
+++ b/python/README.md
@@ -109,6 +109,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [upload_file_in_chunks.py](upload_file_in_chunks.py): upload a file in chunks
 * [API:Pagepropnames](https://www.mediawiki.org/wiki/API:Pagepropnames)
   * [get_pagepropnames.py](get_pagepropnames.py): List all page property names in use on the wiki
+* [API:Protectedtitles](https://www.mediawiki.org/wiki/API:Protectedtitles)
+  * [get_protectedtitles.py](get_protectedtitles.py): List the first 2 titles which only sysops can create
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/get_protectedtitles.py
+++ b/python/get_protectedtitles.py
@@ -1,0 +1,31 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_protectedtitles.py
+
+    MediaWiki API Demos
+    Demo of `Protectedtitles` module: Get the first 2 titles which only sysops can create
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "list": "protectedtitles",
+    "ptlevel": "sysop",
+    "ptlimit": "2"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Sample code for API:Protectedtitles to list the first 2 pages which only sysops can create.
Improved documentation available at https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Protectedtitles