### PR TITLE
Add Python sample code for API:Imageusage

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -450,5 +450,17 @@
             "list": "pagepropnames",
             "format": "json"
         }
+    },
+    {
+        "filename": "get_imageusage",
+        "docstring": "Demo of `Imageusage` module: List the first 3 pages that use a given image title",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "imageusage",
+            "iutitle": "File:Wiki_logo_Nupedia.jpg",
+            "iulimit": "3"
+        }
     }
 ]

--- a/python/README.md
+++ b/python/README.md
@@ -109,6 +109,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [upload_file_in_chunks.py](upload_file_in_chunks.py): upload a file in chunks
 * [API:Pagepropnames](https://www.mediawiki.org/wiki/API:Pagepropnames)
   * [get_pagepropnames.py](get_pagepropnames.py): List all page property names in use on the wiki
+* [API:Imageusage](https://www.mediawiki.org/wiki/API:Imageusage)
+  * [get_imageusage.py](get_imageusage.py): List the first three pages that use a given image title.
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/get_imageusage.py
+++ b/python/get_imageusage.py
@@ -1,0 +1,31 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_imageusage.py
+
+    MediaWiki API Demos
+    Demo of `Imageusage` module: List the first 3 pages that use a given image title
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "list": "imageusage",
+    "iutitle": "File:Wiki_logo_Nupedia.jpg",
+    "iulimit": "3"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Sample code for API:Imageusage to list the first 3 pages that use a given image title.
Improved documentation available at https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Imageusage