### PR TITLE
Sample code for API:Iwlinks

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -475,5 +475,16 @@
             "list": "watchlist",
             "format": "json"
         }
+    },
+    {
+        "filename": "get_iwlinks",
+        "docstring": "Demo of `Iwlinks` module: Get the interwiki links from a given page.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "prop": "iwlinks",
+            "titles": "Albert Einstein"
+        }
     }
 ]

--- a/python/README.md
+++ b/python/README.md
@@ -120,6 +120,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [import_xml.py](import_xml.py): Import a page from another wiki by uploading its xml dump
 * [API:Patrol](https://www.mediawiki.org/wiki/API:Patrol)
   * [patrol.py](patrol.py): Patrol a recent change
+* [API:Iwlinks](https://www.mediawiki.org/wiki/API:Iwlinks)
+  * [get_iwlinks.py](get_iwlinks.py): get the interwiki links from a given page
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/get_iwlinks.py
+++ b/python/get_iwlinks.py
@@ -1,0 +1,30 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_iwlinks.py
+
+    MediaWiki API Demos
+    Demo of `Iwlinks` module: Get the interwiki links from a given page.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "prop": "iwlinks",
+    "titles": "Albert Einstein"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Add sample code for API:Iwlinks to get interwiki links from a page.
Documentation: https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Iwlinks