### PR TITLE
Sample code for API:Undelete

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -115,6 +115,7 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [get_protectedtitles.py](get_protectedtitles.py): List the first 2 titles which only sysops can create
 * [API:Imageusage](https://www.mediawiki.org/wiki/API:Imageusage)
   * [get_imageusage.py](get_imageusage.py): List the first three pages that use a given image title.
+<<<<<<< HEAD
 * [API:Import](https://www.mediawiki.org/wiki/API:Import)
   * [import_interwiki.py](import_interwiki.py): Import a page from another wiki by specifying its title
   * [import_xml.py](import_xml.py): Import a page from another wiki by uploading its xml dump
@@ -122,6 +123,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [patrol.py](patrol.py): Patrol a recent change
 * [API:Iwlinks](https://www.mediawiki.org/wiki/API:Iwlinks)
   * [get_iwlinks.py](get_iwlinks.py): get the interwiki links from a given page
+* [API:Undelete](https://www.mediawiki.org/wiki/API:Undelete)
+  * [undelete.py](undelete.py): restore two revisions of a deleted page
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/README.md
+++ b/python/README.md
@@ -115,7 +115,6 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [get_protectedtitles.py](get_protectedtitles.py): List the first 2 titles which only sysops can create
 * [API:Imageusage](https://www.mediawiki.org/wiki/API:Imageusage)
   * [get_imageusage.py](get_imageusage.py): List the first three pages that use a given image title.
-<<<<<<< HEAD
 * [API:Import](https://www.mediawiki.org/wiki/API:Import)
   * [import_interwiki.py](import_interwiki.py): Import a page from another wiki by specifying its title
   * [import_xml.py](import_xml.py): Import a page from another wiki by uploading its xml dump

--- a/python/undelete.py
+++ b/python/undelete.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+"""
+    undelete.py
+
+    MediaWiki API Demos
+    Demo of `Undelete` module: Restore two revisions of a deleted page
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://test.wikipedia.org/w/api.php"
+
+# Step 1: Retrieve a login token
+PARAMS_1 = {
+    "action": "query",
+    "meta": "tokens",
+    "type": "login",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_1)
+DATA = R.json()
+
+LOGIN_TOKEN = DATA['query']['tokens']['logintoken']
+
+# Step 2: Send a post request to login.
+# Obtain credentials for lgname & lgpassword via Special:BotPasswords
+# (https://www.mediawiki.org/wiki/Special:BotPasswords)
+PARAMS_2 = {
+    "action": "login",
+    "lgname": "username",
+    "lgpassword": "password",
+    "lgtoken": LOGIN_TOKEN,
+    "format": "json"
+}
+
+R = S.post(URL, data=PARAMS_2)
+
+# Step 3: While logged in, get an CSRF token
+PARAMS_3 = {
+    "action": "query",
+    "meta": "tokens",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_3)
+DATA = R.json()
+
+CSRF_TOKEN = DATA["query"]["tokens"]["csrftoken"]
+
+# Step 4: Send a post request to restore two revisions of a deleted page
+PARAMS_4 = {
+    "action": "undelete",
+    "format": "json",
+    "token": CSRF_TOKEN,
+    "title": "Sandbox/Test",
+    "timestamps":"20190605072148|20190605074313",
+    "reason": "Test undeleting via the API"
+}
+
+R = S.post(URL, data=PARAMS_4)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Add sample code for API:Undelete to restore two revisions of a deleted page.
Documentation: https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Undelete