### PR TITLE
Sample code for API:Logevents

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -486,5 +486,16 @@
             "prop": "iwlinks",
             "titles": "Albert Einstein"
         }
+    },
+    {
+        "filename": "get_logevents",
+        "docstring": "Demo of `Logevents` module: Get the three most recent logevents.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "logevents",
+            "lelimit": "3"
+        }
     }
 ]

--- a/python/README.md
+++ b/python/README.md
@@ -124,6 +124,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [get_iwlinks.py](get_iwlinks.py): get the interwiki links from a given page
 * [API:Undelete](https://www.mediawiki.org/wiki/API:Undelete)
   * [undelete.py](undelete.py): restore two revisions of a deleted page
+* [API:Logevents](https://www.mediawiki.org/wiki/API:Logevents)
+  * [get_logevents.py](get_logevents.py): get the three most recent log events
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/get_logevents.py
+++ b/python/get_logevents.py
@@ -1,0 +1,30 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_logevents.py
+
+    MediaWiki API Demos
+    Demo of `Logevents` module: Get the three most recent logevents.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "list": "logevents",
+    "lelimit": "3"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Add sample code for API:Logevents to get the three most recent logevents.
Documentation: https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Logevents