### PR TITLE
Sample code for API:Watchlistraw

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -467,16 +467,6 @@
         }
     },
     {
-        "filename": "get_watchlist",
-        "docstring": "Demo of `Watchlist` module: Get the currently logged-in user's watchlist.",
-        "endpoint": "https://en.wikipedia.org/w/api.php",
-        "params": {
-            "action": "query",
-            "list": "watchlist",
-            "format": "json"
-        }
-    },
-    {
         "filename": "get_iwlinks",
         "docstring": "Demo of `Iwlinks` module: Get the interwiki links from a given page.",
         "endpoint": "https://en.wikipedia.org/w/api.php",

--- a/python/README.md
+++ b/python/README.md
@@ -31,6 +31,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   *  [send_an_email.py](send_an_email.py): send an email to user
 * [API:Watchlist](https://www.mediawiki.org/wiki/API:Watchlist)
   * [get_watchlist.py](get_watchlist.py): get the currently logged-in user's watchlist
+* [API:Watchlistraw](https://www.mediawiki.org/wiki/API:Watchlistraw)
+  * [get_watchlistraw.py](get_watchlistraw.py): get three pages on the logged-in user's watchlist from the main namespace
 
 ### Page Operations
 * [API:Parse](https://www.mediawiki.org/wiki/API:Parse)

--- a/python/get_watchlist.py
+++ b/python/get_watchlist.py
@@ -1,5 +1,3 @@
-#This file is auto-generated. See modules.json and autogenerator.py for details
-
 #!/usr/bin/python3
 
 """

--- a/python/get_watchlistraw.py
+++ b/python/get_watchlistraw.py
@@ -1,0 +1,61 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_watchlistraw.py
+
+    MediaWiki API Demos
+    Demo of `Watchlistraw` module: Get three pages on the logged-in user's
+    watchlist from the main namespace.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+# Step 1: Retrieve a login token
+PARAMS_1 = {
+    "action": "query",
+    "meta": "tokens",
+    "type": "login",
+    "format": "json"
+}
+
+R = S.get(url=URL, params=PARAMS_1)
+DATA = R.json()
+
+LOGIN_TOKEN = DATA['query']['tokens']['logintoken']
+
+# Step 2: Send a post request to log in. For this login
+# method, Obtain bot credentials by visiting
+# https://en.wikipedia.org/wiki/Special:BotPasswords/
+# See https://www.mediawiki.org/wiki/API:Login for more
+# information on log in methods.
+PARAMS_2 = {
+    "action": "login",
+    "lgname": "username",
+    "lgpassword": "password",
+    "format": "json",
+    "lgtoken": LOGIN_TOKEN
+}
+
+R = S.post(URL, data=PARAMS_2)
+
+# Step 3: While logged in, get the watchlist
+PARAMS_3 = {
+    "action": "query",
+    "list": "watchlistraw",
+    "format": "json",
+    "wrnamespace": "0",
+    "wrlimit": "3"
+}
+
+R = S.get(url=URL, params=PARAMS_3)
+DATA = R.json()
+
+print(DATA)

--- a/python/get_watchlistraw.py
+++ b/python/get_watchlistraw.py
@@ -1,5 +1,3 @@
-#This file is auto-generated. See modules.json and autogenerator.py for details
-
 #!/usr/bin/python3
 
 """


### PR DESCRIPTION
Add sample code for API:Watchlistraw to get three pages on the logged-in user's watchlist from the main namespace.
Documentation: https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Watchlistraw