### PR TITLE
Sample code for API:Allredirects

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -499,5 +499,18 @@
             "tgprop":"hitcount",
             "tglimit": "3"
         }
+    },
+    {
+        "filename": "get_allredirects",
+        "docstring": "Demo of `Allredirects` module: Get the first three unique pages containing redirects to the main namespace.",
+        "endpoint": "https://en.wikipedia.org/w/api.php",
+        "params": {
+            "action": "query",
+            "format": "json",
+            "list": "allredirects",
+            "arunique": "1",
+            "arnamespace": "0",
+            "arlimit": "3"
+        }
     }
 ]

--- a/python/README.md
+++ b/python/README.md
@@ -130,6 +130,8 @@ Code snippets in Python demonstrating how to use various modules of the [MediaWi
   * [get_logevents.py](get_logevents.py): get the three most recent log events
 * [API:Tags](https://www.mediawiki.org/wiki/API:Tags)
   * [get_tags.py](get_tags.py): get the first three change tags and their hitcounts
+* [API:Allredirects](https://www.mediawiki.org/wiki/API:Allredirects)
+  * [get_allredirects.py](get_allredirects.py): get the first three unique pages containing redirects to the main namespace
 
 ### Search 
 * [API:Search](https://www.mediawiki.org/wiki/API:Search)

--- a/python/get_allredirects.py
+++ b/python/get_allredirects.py
@@ -1,0 +1,33 @@
+#This file is auto-generated. See modules.json and autogenerator.py for details
+
+#!/usr/bin/python3
+
+"""
+    python/get_allredirects.py
+
+    MediaWiki API Demos
+    Demo of `Allredirects` module: Get the first three unique pages containing
+    redirects to the main namespace.
+
+    MIT License
+"""
+
+import requests
+
+S = requests.Session()
+
+URL = "https://en.wikipedia.org/w/api.php"
+
+PARAMS = {
+    "action": "query",
+    "format": "json",
+    "list": "allredirects",
+    "arunique": "1",
+    "arnamespace": "0",
+    "arlimit": "3"
+}
+
+R = S.get(url=URL, params=PARAMS)
+DATA = R.json()
+
+print(DATA)


### PR DESCRIPTION
Add sample code for API:Allredirects to get the first three unique pages containing redirects to the main namespace.
Documentation: https://www.mediawiki.org/wiki/User:Jeropbrenda/Sandbox/API:Allredirects