### PR TITLE
Add File Upload API Sample for MediaWiki JS

### DIFF
--- a/mediawikijs/upload_file_directly.js
+++ b/mediawikijs/upload_file_directly.js
@@ -1,0 +1,26 @@
+/*
+    upload_file_directly.js
+
+    MediaWiki API Demos
+    Demo of `Upload` module: Sending post request to upload a file directly
+    MIT license
+*/
+
+var param = {
+		filename: 'File_1.jpg',
+		format: 'json',
+		ignorewarnings: 1
+	},
+	fileInput = $( '<input/>' ).attr( 'type', 'file' ),
+	submitBtn = $( '<input/>' ).attr( 'type', 'button' ).attr( 'value', 'Upload' ),
+	api = new mw.Api();
+
+$( '#bodyContent' ).append( [ fileInput, submitBtn ] );
+
+$( submitBtn ).on( 'click', function () {
+	api.upload( fileInput[ 0 ], param ).done( function ( data ) {
+		console.log( data.upload.filename + ' has sucessfully uploaded.' );
+	} ).fail( function ( data ) {
+		console.log( data );
+	} );
+} );

--- a/mediawikijs/upload_file_in_chunks.js
+++ b/mediawikijs/upload_file_in_chunks.js
@@ -1,0 +1,28 @@
+/*
+    upload_file_in_chunks.js
+
+    MediaWiki API Demos
+    Demo of `Upload` module: Step-by-step process to upload a file in chunks
+    MIT license
+*/
+
+var param = {
+		filename: 'TestFile_2.jpg',
+		format: 'json',
+		ignorewarnings: 1
+	},
+	fileInput = $( '<input/>' ).attr( 'type', 'file' ),
+	submitBtn = $( '<input/>' ).attr( 'type', 'button' ).attr( 'value', 'Upload' ),
+	api = new mw.Api();
+
+$( '#bodyContent' ).append( [ fileInput, submitBtn ] );
+
+$( submitBtn ).on( 'click', function () {
+	api.uploadToStash( fileInput[ 0 ], param ).done( function ( finish ) {
+		finish( param ).done( function ( data ) {
+			console.log( data.upload.filename + ' has sucessfully uploaded.' );
+		} ).fail( function ( data ) {
+			console.log( data );
+		} );
+	} );
+} );


### PR DESCRIPTION
Add File Upload API Sample for MediaWiki JS

```
Jay-Prakash:Gadget administrator$ eslint upload_file_directly.js

/Users/administrator/Gadget/upload_file_directly.js
  18:1  error  Global selectors are not allowed  no-jquery/no-global-selector

✖ 1 problem (1 error, 0 warnings)

Jay-Prakash:Gadget administrator$ eslint upload_file_in_chunks.js

/Users/administrator/Gadget/upload_file_in_chunks.js
  18:1  error  Global selectors are not allowed  no-jquery/no-global-selector

✖ 1 problem (1 error, 0 warnings)
```
By doing linting, I am getting only one error. This is because, I am using Standard .eslintrc.json config file. which mostly used for MediaWiki Extension. You can rid out the error by just adding `no-global-selector` in .eslintrc.json :)