### PR TITLE
add "web" to "apps"

### DIFF
--- a/gallery/templates/apps.html
+++ b/gallery/templates/apps.html
@@ -31,7 +31,7 @@
     <div class="album">
       <div class="container">
         <div class="row">
-          <p class="lead grayed-text">A showcase of interactive demo apps built using the <a href="//www.mediawiki.org/wiki/API:Main_page">MediaWiki Action API</a>. To submit your app, read the <a href="https://github.com/wikimedia/mediawiki-api-demos/tree/master/gallery/contributing.md" target="_blank">contribution guidelines</a>.
+          <p class="lead grayed-text">A showcase of interactive demo web apps built using the <a href="//www.mediawiki.org/wiki/API:Main_page">MediaWiki Action API</a>. To submit your app, read the <a href="https://github.com/wikimedia/mediawiki-api-demos/tree/master/gallery/contributing.md" target="_blank">contribution guidelines</a>.
 
           {% for app in apps %}
           <div class="col-lg-4 col-md-6 col-xs-12">


### PR DESCRIPTION
I suggest using "web apps" for the first instance of "apps", so that non-technical people who find this page aren't confused about whether this are "mobile apps".