### PR TITLE
corrected the github url of the user-contributions-feed app

### DIFF
--- a/gallery/apps.json
+++ b/gallery/apps.json
@@ -49,7 +49,7 @@
 		"thumbnail": "static/user_contributions_feed.png",
 		"description": "Fetches top 50 edits made by a user",
 		"modules": ["usercontribs"],
-		"source": "https://github.com/wikimedia/mediawiki-api-demos/tree/master/apps/article-ideas-generator",
+		"source": "https://github.com/wikimedia/mediawiki-api-demos/tree/master/apps/user-contributions-feed",
 		"owner": "Jayprakash-SE",
 		"url": "https://tools.wmflabs.org/user-contributions-feed/"
 	},


### PR DESCRIPTION
Prior to this PR, clicking on the "view on github" button of the User Contributions app on the app gallery sends you instead to [article-ideas-generator](https://github.com/wikimedia/mediawiki-api-demos/tree/master/apps/article-ideas-generator) app.

This PR corrected it to point to the correct URL [user-contributions-app](https://github.com/wikimedia/mediawiki-api-demos/tree/master/apps/user-contributions-feed)
*issue fixed*: #223