### PR TITLE
Remove disfunctional "Try it out" link for Wiki Login tool

### DIFF
--- a/gallery/apps.json
+++ b/gallery/apps.json
@@ -69,7 +69,7 @@
 		"modules": ["tokens", "login"],
 		"source": "https://github.com/wikimedia/mediawiki-api-demos/tree/master/apps/client-login",
 		"owner": "srish",
-		"url": "http://tools.wmflabs.org"
+		"url": ""
 	},
 	{
 		"title": "Article Ideas",


### PR DESCRIPTION
Fixes #235