### PR TITLE
Change source URL of MassMailer from Phabricator to Gerrit

### DIFF
--- a/gallery/apps.json
+++ b/gallery/apps.json
@@ -157,7 +157,7 @@
 		"thumbnail": "static/mass-mailer.png",
 		"description": "Emails wiki users en masse",
 		"modules": [ "emailuser", "tokens" ],
-		"source": "https://phabricator.wikimedia.org/source/tool-massmailer/",
+		"source": "https://gerrit.wikimedia.org/g/labs/tools/massmailer",
 		"owner": "Urbanecm",
 		"url": "https://tools.wmflabs.org/massmailer/"
 	},


### PR DESCRIPTION
Code review happens on Gerrit. Linking to the mirrored repository in Phabricator is misleading for new contributors.